### PR TITLE
Changed thread_tags.py to send Home Assistant discovery messages

### DIFF
--- a/py/thread_tags/cfg.py
+++ b/py/thread_tags/cfg.py
@@ -68,7 +68,8 @@ def configure_log(logger_name):
     log.basicConfig(    filename=logfile,
                         level=log_level_map[config["level"]],
                         format='%(asctime)s %(name)s %(levelname)-8s %(message)s',
-                        datefmt='%d %H:%M:%S'
+                        datefmt='%d %H:%M:%S',
+                        force=True
                         )
     log.getLogger('').addHandler(log.StreamHandler())
     log.info("====> '%s' started logging with level '%s' @ '%s'"%(logger_name,config["level"],str(datetime.datetime.utcnow())))

--- a/py/thread_tags/cfg.py
+++ b/py/thread_tags/cfg.py
@@ -1,4 +1,4 @@
-import sys,os
+import sys, os, os.path
 import json
 import logging as log
 import socket
@@ -62,6 +62,10 @@ def configure_log(logger_name):
     }
     #if(os.path.isfile(config["logfile"])):
     logfile = config["logfile"].replace("(date)",datetime.datetime.now().strftime('-%Y.%m.%d'))
+
+    if not os.path.exists("var/log/thread/"):
+        os.makedirs("var/log/thread/")
+
     print(f"logging in file '{logfile}'")
     for handler in log.root.handlers[:]:
         log.root.removeHandler(handler)

--- a/py/thread_tags/cfg.py
+++ b/py/thread_tags/cfg.py
@@ -73,8 +73,7 @@ def configure_log(logger_name):
                         filename=logfile,
                         level=log_level_map[config["level"]],
                         format='%(asctime)s %(name)s %(levelname)-8s %(message)s',
-                        datefmt='%d %H:%M:%S',
-                        force=True
+                        datefmt='%d %H:%M:%S'
                     )
     log.getLogger('').addHandler(log.StreamHandler())
     log.info("====> '%s' started logging with level '%s' @ '%s'"%(logger_name,config["level"],str(datetime.datetime.utcnow())))

--- a/py/thread_tags/cfg.py
+++ b/py/thread_tags/cfg.py
@@ -62,14 +62,16 @@ def configure_log(logger_name):
     }
     #if(os.path.isfile(config["logfile"])):
     logfile = config["logfile"].replace("(date)",datetime.datetime.now().strftime('-%Y.%m.%d'))
-    #log.info(f"logging in file '{logfile}'")
+    print(f"logging in file '{logfile}'")
     for handler in log.root.handlers[:]:
         log.root.removeHandler(handler)
-    log.basicConfig(    filename=logfile,
+    log.basicConfig(
+                        filename=logfile,
                         level=log_level_map[config["level"]],
                         format='%(asctime)s %(name)s %(levelname)-8s %(message)s',
-                        datefmt='%d %H:%M:%S'
-                        )
+                        datefmt='%d %H:%M:%S',
+                        force=True
+                    )
     log.getLogger('').addHandler(log.StreamHandler())
     log.info("====> '%s' started logging with level '%s' @ '%s'"%(logger_name,config["level"],str(datetime.datetime.utcnow())))
     #else:

--- a/py/thread_tags/cfg.py
+++ b/py/thread_tags/cfg.py
@@ -62,14 +62,13 @@ def configure_log(logger_name):
     }
     #if(os.path.isfile(config["logfile"])):
     logfile = config["logfile"].replace("(date)",datetime.datetime.now().strftime('-%Y.%m.%d'))
-    log.info(f"logging in file '{logfile}'")
+    #log.info(f"logging in file '{logfile}'")
     for handler in log.root.handlers[:]:
         log.root.removeHandler(handler)
     log.basicConfig(    filename=logfile,
                         level=log_level_map[config["level"]],
                         format='%(asctime)s %(name)s %(levelname)-8s %(message)s',
-                        datefmt='%d %H:%M:%S',
-                        force=True
+                        datefmt='%d %H:%M:%S'
                         )
     log.getLogger('').addHandler(log.StreamHandler())
     log.info("====> '%s' started logging with level '%s' @ '%s'"%(logger_name,config["level"],str(datetime.datetime.utcnow())))

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -32,7 +32,7 @@ def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
 
 def send_config_message(uid, device_class, valuetag, unit_of_measurement):
     payload = generate_config_payload(uid, device_class, valuetag, unit_of_measurement)
-    topoic = "homeassistant/sensor/"+uid+"/"+device_class+"/config"
+    topic = "homeassistant/sensor/"+uid+"/"+device_class+"/config"
     log.info(f"'{topic}' => '{payload}'")
     clientMQTT.publish(topic, payload)
 

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -12,8 +12,8 @@ UDP_PORT = 4242
 def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
     #{"alive":8589,"voltage":3.245,"light":2266.726,"temperature":-0.56,"humidity":59.12,"pressure":1027.39}
     return {
-        "name": "TST-["+uid+"]("+device_class+")",
-        "obj_id": "tst_"+uid+"_"+valuetag,
+        "name": device_class+"[+"uid"+]",
+        "obj_id": "thread_sensor_tag_"+uid+"_"+valuetag,
         "~": "homeassistant/sensor/"+uid,
         "uniq_id": uid+"#"+valuetag,
         "state_topic": "~/state",

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -12,8 +12,8 @@ UDP_PORT = 4242
 def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
     #{"alive":8589,"voltage":3.245,"light":2266.726,"temperature":-0.56,"humidity":59.12,"pressure":1027.39}
     return {
-        "name": "Thread Sensor Tag ("+device_class+")",
-        "obj_id": "thread_sensor_tag_"+uid+"_"+valuetag,
+        "name": "TST-["+uid+"]("+device_class+")",
+        "obj_id": "tst_"+uid+"_"+valuetag,
         "~": "homeassistant/sensor/"+uid,
         "uniq_id": uid+"#"+valuetag,
         "state_topic": "~/state",

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -34,7 +34,7 @@ def send_config_message(uid, device_class, valuetag, unit_of_measurement):
     payload = generate_config_payload(uid, device_class, valuetag, unit_of_measurement)
     topic = "homeassistant/sensor/"+uid+"/"+device_class+"/config"
     log.info(f"'{topic}' => '{payload}'")
-    clientMQTT.publish(topic, payload)
+    clientMQTT.publish(topic, payload, retain=True)
 
 def send_all_config_messages(uid):
     send_config_message(uid, "duration", "alive", "ms")

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -12,7 +12,7 @@ UDP_PORT = 4242
 def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
     #{"alive":8589,"voltage":3.245,"light":2266.726,"temperature":-0.56,"humidity":59.12,"pressure":1027.39}
     return {
-        "name": device_class+"[+"uid"+]",
+        "name": device_class+"["+uid+"]",
         "obj_id": "thread_sensor_tag_"+uid+"_"+valuetag,
         "~": "homeassistant/sensor/"+uid,
         "uniq_id": uid+"#"+valuetag,

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -1,21 +1,9 @@
-#https://pypi.python.org/pypi/paho-mqtt/1.1
 import paho.mqtt.client as mqtt
 import socket 
 import logging as log
 import cfg
 from mqtt import mqtt_start
 import time
-
-def friendly_topic(topic):
-    if('/' not in topic):
-        return topic
-    base_topic = topic.split('/')[0]
-    long_name =  topic.split('/')[1]
-    if(long_name in config["friendlyNames"]):
-        name = config["friendlyNames"][long_name]
-    else:
-        name = long_name
-    return base_topic+'/'+name
 
 UDP_IP = "::" # = 0.0.0.0 u IPv4
 UDP_PORT = 4242
@@ -31,8 +19,49 @@ clientMQTT = mqtt_start(config,None,True)
 while True:
     data, addr = sock.recvfrom(1024) # buffer size is 1024 bytes
     message = data.decode("utf-8")
+    log.info("udp message: " + message)
     parts = message.split("{")
-    topic = friendly_topic(parts[0])
+    uid = parts[0].split('/')[1]
+    send_all_config_messages(uid)
+
+    topic = "homeassistant/sensor/"+uid+"/state"
     payload = '{'+parts[1].rstrip('\n')
     log.info(f"'{topic}' => {payload}")
-    clientMQTT.publish(topic,payload)
+    clientMQTT.publish(topic, payload)
+
+def send_all_config_messages(uid):
+    send_config_message(uid, "duration", "alive", "ms")
+    send_config_message(uid, "battery", "voltage", "V")
+    send_config_message(uid, "temperature", "temperature", "°C")
+    send_config_message(uid, "humidity", "humidity", "%")
+    send_config_message(uid, "presssure", "pressure", "Pa")
+    send_config_message(uid, "illuminance", "light", "lx")
+
+def send_config_message(uid, device_class, valuetag, unit_of_measurement):
+    payload = generate_config_payload(uid, device_class, valuetag, unit_of_measurement)
+    topoic = "homeassistant/sensor/"+uid+"/"+device_class+"/config"
+    log.info(f"'{topic}' => '{payload}'")
+    clientMQTT.publish(topic, payload)
+
+def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
+    #{"alive":8589,"voltage":3.245,"light":2266.726,"temperature":-0.56,"humidity":59.12,"pressure":1027.39}
+    return {
+        "name": "Thread Sensor Tag ("+device_class+")",
+        "obj_id": "thread_sensor_tag_"+uid+"_"+valuetag,
+        "~": "homeassistant/sensor/"+uid,
+        "uniq_id": uid+"#"+valuetag,
+        "state_topic": "~/state",
+        "unit_of_measurement": unit_of_measurement,
+        "device_class": device_class,
+        "value_template": "{{ value_json."+valuetag+" }}",
+        "force_update": true,
+        "device": {
+            "identifiers": [
+                uid
+            ],
+            "manufacturer": "open-things.de",
+            "model": "Thread Sensor Tag",
+            "name": "Thread Sensor Tag ["+uid+"]"
+        }
+    }
+

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -23,7 +23,7 @@ def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
         "force_update": True,
         "device": {
             "identifiers": [
-                uid
+                strr(uid)
             ],
             "manufacturer": "open-things.de",
             "model": "Thread Sensor Tag",
@@ -38,12 +38,12 @@ def send_config_message(uid, device_class, valuetag, unit_of_measurement):
     clientMQTT.publish(topic, json.dumps(payload), retain=True)
 
 def send_all_config_messages(uid):
-    send_config_message(uid, "duration", "alive", "ms")
-    send_config_message(uid, "battery", "voltage", "V")
-    send_config_message(uid, "temperature", "temperature", "°C")
-    send_config_message(uid, "humidity", "humidity", "%")
-    send_config_message(uid, "presssure", "pressure", "Pa")
-    send_config_message(uid, "illuminance", "light", "lx")
+    send_config_message(uid, "duration",    "alive",        "ms")
+    send_config_message(uid, "battery",     "voltage",      "V")
+    send_config_message(uid, "temperature", "temperature",  "°C")
+    send_config_message(uid, "humidity",    "humidity",     "%")
+    send_config_message(uid, "pressure",    "pressure",     "Pa")
+    send_config_message(uid, "illuminance", "light",        "lx")
 
 sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) # UDP
 sock.bind((UDP_IP, UDP_PORT))

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -10,7 +10,7 @@ UDP_PORT = 4242
 
 def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
     #{"alive":8589,"voltage":3.245,"light":2266.726,"temperature":-0.56,"humidity":59.12,"pressure":1027.39}
-    return {
+    return str({
         "name": "Thread Sensor Tag ("+device_class+")",
         "obj_id": "thread_sensor_tag_"+uid+"_"+valuetag,
         "~": "homeassistant/sensor/"+uid,
@@ -28,7 +28,7 @@ def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
             "model": "Thread Sensor Tag",
             "name": "Thread Sensor Tag ["+uid+"]"
         }
-    }
+    })
 
 def send_config_message(uid, device_class, valuetag, unit_of_measurement):
     payload = generate_config_payload(uid, device_class, valuetag, unit_of_measurement)

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -12,7 +12,7 @@ UDP_PORT = 4242
 def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
     #{"alive":8589,"voltage":3.245,"light":2266.726,"temperature":-0.56,"humidity":59.12,"pressure":1027.39}
     return {
-        "name": device_class.capitalize()+" ["+uid+"]",
+        "name": device_class.capitalize(),
         "obj_id": "thread_sensor_tag_"+uid+"_"+valuetag,
         "~": "homeassistant/sensor/"+uid,
         "uniq_id": uid+"#"+valuetag,

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -65,24 +65,3 @@ while True:
     payload = '{'+parts[1].rstrip('\n')
     log.info(f"'{topic}' => {payload}")
     clientMQTT.publish(topic, payload)
-
-
-
-'homeassistant/sensor/25B8E0117530C478/duration/config'
-{
-    'name': 'Thread Sensor Tag (duration)', 
-    'obj_id': 'thread_sensor_tag_25B8E0117530C478_alive', 
-    '~': 'homeassistant/sensor/25B8E0117530C478', 
-    'uniq_id': '25B8E0117530C478#alive', 
-    'state_topic': '~/state', 
-    'unit_of_measurement': 'ms', 
-    'device_class': 'duration', 
-    'value_template': '{{ value_json.alive }}', 
-    'force_update': True, 
-    'device': {
-        'identifiers': ['25B8E0117530C478'], 
-        'manufacturer': 'open-things.de', 
-        'model': 'Thread Sensor Tag', 
-        'name': 'Thread Sensor Tag [25B8E0117530C478]'
-    }
-}

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -8,41 +8,6 @@ import time
 UDP_IP = "::" # = 0.0.0.0 u IPv4
 UDP_PORT = 4242
 
-sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) # UDP
-sock.bind((UDP_IP, UDP_PORT))
-
-# -------------------- main -------------------- 
-config = cfg.configure_log(__file__)
-#will start a separate thread for looping
-clientMQTT = mqtt_start(config,None,True)
-
-while True:
-    data, addr = sock.recvfrom(1024) # buffer size is 1024 bytes
-    message = data.decode("utf-8")
-    log.info("udp message: " + message)
-    parts = message.split("{")
-    uid = parts[0].split('/')[1]
-    send_all_config_messages(uid)
-
-    topic = "homeassistant/sensor/"+uid+"/state"
-    payload = '{'+parts[1].rstrip('\n')
-    log.info(f"'{topic}' => {payload}")
-    clientMQTT.publish(topic, payload)
-
-def send_all_config_messages(uid):
-    send_config_message(uid, "duration", "alive", "ms")
-    send_config_message(uid, "battery", "voltage", "V")
-    send_config_message(uid, "temperature", "temperature", "°C")
-    send_config_message(uid, "humidity", "humidity", "%")
-    send_config_message(uid, "presssure", "pressure", "Pa")
-    send_config_message(uid, "illuminance", "light", "lx")
-
-def send_config_message(uid, device_class, valuetag, unit_of_measurement):
-    payload = generate_config_payload(uid, device_class, valuetag, unit_of_measurement)
-    topoic = "homeassistant/sensor/"+uid+"/"+device_class+"/config"
-    log.info(f"'{topic}' => '{payload}'")
-    clientMQTT.publish(topic, payload)
-
 def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
     #{"alive":8589,"voltage":3.245,"light":2266.726,"temperature":-0.56,"humidity":59.12,"pressure":1027.39}
     return {
@@ -65,3 +30,37 @@ def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
         }
     }
 
+def send_config_message(uid, device_class, valuetag, unit_of_measurement):
+    payload = generate_config_payload(uid, device_class, valuetag, unit_of_measurement)
+    topoic = "homeassistant/sensor/"+uid+"/"+device_class+"/config"
+    log.info(f"'{topic}' => '{payload}'")
+    clientMQTT.publish(topic, payload)
+
+def send_all_config_messages(uid):
+    send_config_message(uid, "duration", "alive", "ms")
+    send_config_message(uid, "battery", "voltage", "V")
+    send_config_message(uid, "temperature", "temperature", "°C")
+    send_config_message(uid, "humidity", "humidity", "%")
+    send_config_message(uid, "presssure", "pressure", "Pa")
+    send_config_message(uid, "illuminance", "light", "lx")
+
+sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) # UDP
+sock.bind((UDP_IP, UDP_PORT))
+
+# -------------------- main -------------------- 
+config = cfg.configure_log(__file__)
+#will start a separate thread for looping
+clientMQTT = mqtt_start(config,None,True)
+
+while True:
+    data, addr = sock.recvfrom(1024) # buffer size is 1024 bytes
+    message = data.decode("utf-8")
+    log.info("udp message: " + message)
+    parts = message.split("{")
+    uid = parts[0].split('/')[1]
+    send_all_config_messages(uid)
+
+    topic = "homeassistant/sensor/"+uid+"/state"
+    payload = '{'+parts[1].rstrip('\n')
+    log.info(f"'{topic}' => {payload}")
+    clientMQTT.publish(topic, payload)

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -19,7 +19,7 @@ def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
         "unit_of_measurement": unit_of_measurement,
         "device_class": device_class,
         "value_template": "{{ value_json."+valuetag+" }}",
-        "force_update": true,
+        "force_update": True,
         "device": {
             "identifiers": [
                 uid

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -23,7 +23,7 @@ def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
         "force_update": True,
         "device": {
             "identifiers": [
-                strr(uid)
+                str(uid)
             ],
             "manufacturer": "open-things.de",
             "model": "Thread Sensor Tag",

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -39,7 +39,7 @@ def send_config_message(uid, device_class, valuetag, unit_of_measurement):
 
 def send_all_config_messages(uid):
     send_config_message(uid, "duration",    "alive",        "ms")
-    send_config_message(uid, "battery",     "voltage",      "V")
+    send_config_message(uid, "voltage",     "voltage",      "V")
     send_config_message(uid, "temperature", "temperature",  "°C")
     send_config_message(uid, "humidity",    "humidity",     "%")
     send_config_message(uid, "pressure",    "pressure",     "Pa")

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -12,7 +12,7 @@ UDP_PORT = 4242
 def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
     #{"alive":8589,"voltage":3.245,"light":2266.726,"temperature":-0.56,"humidity":59.12,"pressure":1027.39}
     return {
-        "name": device_class+"["+uid+"]",
+        "name": device_class.capitalize()+" ["+uid+"]",
         "obj_id": "thread_sensor_tag_"+uid+"_"+valuetag,
         "~": "homeassistant/sensor/"+uid,
         "uniq_id": uid+"#"+valuetag,

--- a/py/thread_tags/thread_tags.py
+++ b/py/thread_tags/thread_tags.py
@@ -4,13 +4,14 @@ import logging as log
 import cfg
 from mqtt import mqtt_start
 import time
+import json
 
 UDP_IP = "::" # = 0.0.0.0 u IPv4
 UDP_PORT = 4242
 
 def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
     #{"alive":8589,"voltage":3.245,"light":2266.726,"temperature":-0.56,"humidity":59.12,"pressure":1027.39}
-    return str({
+    return {
         "name": "Thread Sensor Tag ("+device_class+")",
         "obj_id": "thread_sensor_tag_"+uid+"_"+valuetag,
         "~": "homeassistant/sensor/"+uid,
@@ -28,13 +29,13 @@ def generate_config_payload(uid, device_class, valuetag, unit_of_measurement):
             "model": "Thread Sensor Tag",
             "name": "Thread Sensor Tag ["+uid+"]"
         }
-    })
+    }
 
 def send_config_message(uid, device_class, valuetag, unit_of_measurement):
     payload = generate_config_payload(uid, device_class, valuetag, unit_of_measurement)
     topic = "homeassistant/sensor/"+uid+"/"+device_class+"/config"
     log.info(f"'{topic}' => '{payload}'")
-    clientMQTT.publish(topic, payload, retain=True)
+    clientMQTT.publish(topic, json.dumps(payload), retain=True)
 
 def send_all_config_messages(uid):
     send_config_message(uid, "duration", "alive", "ms")
@@ -64,3 +65,24 @@ while True:
     payload = '{'+parts[1].rstrip('\n')
     log.info(f"'{topic}' => {payload}")
     clientMQTT.publish(topic, payload)
+
+
+
+'homeassistant/sensor/25B8E0117530C478/duration/config'
+{
+    'name': 'Thread Sensor Tag (duration)', 
+    'obj_id': 'thread_sensor_tag_25B8E0117530C478_alive', 
+    '~': 'homeassistant/sensor/25B8E0117530C478', 
+    'uniq_id': '25B8E0117530C478#alive', 
+    'state_topic': '~/state', 
+    'unit_of_measurement': 'ms', 
+    'device_class': 'duration', 
+    'value_template': '{{ value_json.alive }}', 
+    'force_update': True, 
+    'device': {
+        'identifiers': ['25B8E0117530C478'], 
+        'manufacturer': 'open-things.de', 
+        'model': 'Thread Sensor Tag', 
+        'name': 'Thread Sensor Tag [25B8E0117530C478]'
+    }
+}


### PR DESCRIPTION
With this changes the thread tag will be integrated into home-assistant automagically. All you need to do is to setup the MQTT integration using the correct broker.

The script is now sending a config message for each "sensor" entity. In our case battery, duration, illumincance, humidity, pressure, temperature. This will be recognized by home assistant automatically using the MQTT discovery function which is enabled by default if the MQTT Integration is  installed.